### PR TITLE
Update 2021-11-28-kang21a.md

### DIFF
--- a/_posts/2021-11-28-kang21a.md
+++ b/_posts/2021-11-28-kang21a.md
@@ -1,5 +1,5 @@
 ---
-title: Improving Hashing Algorithms for Similarity Search \textitvia MLE and the Control
+title: Improving Hashing Algorithms for Similarity Search via MLE and the Control
   Variates Trick
 section: Contributed Papers
 crossref: acml21


### PR DESCRIPTION
Changed \textitvia to via in title.

Previously, was "Improving Hashing Algorithms for Similarity Search \textitvia MLE and the Control Variates Trick"
when it really should have been
Improving Hashing Algorithms for Similarity Search via MLE and the Control Variates Trick